### PR TITLE
Fixed Typographical Error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ import {
   MessageList,
   MessageHeader
 } from "@minchat/react-chat-ui";
-Pdash
 function App() {
   return (
     <MinChatUiProvider theme="#6ea9d7">


### PR DESCRIPTION
Removed the stray 'Pdash' expression from the App.js code snippet in the README, resolving the eslint error messages for unexpected expression and undefined reference.